### PR TITLE
ci(github): add size-limit workflow

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,0 +1,15 @@
+name: size
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  size:
+    runs-on: ubuntu-latest
+    env:
+      CI_JOB_NUMBER: 1
+    steps:
+      - uses: actions/checkout@v2
+      - uses: andresz1/size-limit-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,0 +1,6 @@
+[
+  {
+    "path": "umd/mdtocs.min.js",
+    "limit": "500 B"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@rollup/plugin-typescript": "^8.1.0",
+    "@size-limit/preset-small-lib": "^4.9.1",
     "@types/jest": "^26.0.19",
     "@typescript-eslint/eslint-plugin": "^4.10.0",
     "@typescript-eslint/parser": "^4.10.0",
@@ -52,6 +53,7 @@
     "prettier": "^2.2.1",
     "rollup": "^2.35.1",
     "rollup-plugin-terser": "^7.0.2",
+    "size-limit": "^4.9.1",
     "standard-version": "^9.0.0",
     "ts-jest": "^26.4.4",
     "typescript": "^4.1.3"


### PR DESCRIPTION
## What is the motivation for this pull request?

ci(github): add GitHub Actions workflow `size-limit`
