### PR TITLE
fix(utils): clean code blocks with heading-like syntax

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
     "path": "umd/mdtocs.min.js",
-    "limit": "700 B"
+    "limit": "800 B"
   }
 ]

--- a/__tests__/__fixtures__/no-headings.md
+++ b/__tests__/__fixtures__/no-headings.md
@@ -45,4 +45,19 @@ Code block
 ![](/image.png)
 
 ***
+
+```markdown
+# Heading inside code block
+```
+
+```python
+# comment
+```
+
+```
+## 2
+### 3
+
+#### 4
+```
 <!-- prettier-ignore-end -->

--- a/__tests__/utils/clean.test.ts
+++ b/__tests__/utils/clean.test.ts
@@ -1,0 +1,14 @@
+import { clean } from '../../src/utils/clean';
+
+describe('parse', () => {
+  it.each([
+    '```\n```',
+    '```\n```\n',
+    '```py\n```',
+    '```py\n# comment\n```',
+    '```markdown\n\n\n```',
+    '```\n```\n```\n```',
+  ])('removes code block', (markdown) => {
+    expect(clean(markdown)).toBe('');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -10,15 +10,16 @@
     "build:umd": "rollup --config",
     "clean": "rm -rf cjs umd",
     "lint": "npm run lint:js && npm run lint:ts && npm run lint:tsc",
+    "lint:fix": "npm run lint:js -- --fix && npm run lint:ts -- --fix",
     "lint:js": "eslint --ignore-path .gitignore .",
     "lint:ts": "npm run lint:js -- --ext .ts",
     "lint:tsc": "tsc --noEmit",
-    "lint:fix": "npm run lint:js -- --fix && npm run lint:ts -- --fix",
-    "prepublishOnly": "pinst --disable && npm run lint && npm test && npm run clean && npm run build",
-    "test": "jest --coverage",
-    "test:watch": "jest --watch",
     "postinstall": "husky install",
-    "postpublish": "pinst --enable"
+    "postpublish": "pinst --enable",
+    "prepublishOnly": "pinst --disable && npm run lint && npm test && npm run clean && npm run build",
+    "size": "npm run build && size-limit",
+    "test": "jest --coverage",
+    "test:watch": "jest --watch"
   },
   "homepage": "https://remarkablemark.org/mdtocs/",
   "repository": {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,15 +1,17 @@
 /**
  * @see {@link https://www.markdownguide.org/basic-syntax/}
+ * @see {@link https://regexr.com/}
  */
-export const HEADING_REGEX = /^(#+)[ \t](.+)$|^(.+)[\r\n]([=-])/;
+export const CODE_BLOCK_REGEX = /^```.*\n[\s\S]*?```$/gm;
 export const HEADINGS_REGEX = /^(#{1,6}[ \t].+)$|^(.+[\r\n][=-]{3,})$/gm;
+export const HEADING_REGEX = /^(#+)[ \t](.+)$|^(.+)[\r\n]([=-])/;
+export const INVALID_FRAGMENT_REGEX = /[^a-zA-Z0-9_-]/g;
+export const WHITESPACE_REGEX = /\s/;
 
+export const BLANK = '';
 export const HYPHEN = '-';
 export const NEWLINE = '\n';
 const SPACE = ' ';
 
 export const INDENT = SPACE.repeat(2);
 export const BULLET = HYPHEN + SPACE;
-
-export const INVALID_FRAGMENT_REGEX = /[^a-zA-Z0-9_-]/g;
-export const WHITESPACE_REGEX = /\s/;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { parse, transform, validate } from './utils';
+import { clean, parse, transform, validate } from './utils';
 
 /**
  * Generates table of contents given Markdown.
@@ -8,5 +8,5 @@ import { parse, transform, validate } from './utils';
  * @throws - The first argument must be a string.
  */
 export function mdtocs(markdown: string): string {
-  return transform(parse(validate(markdown)));
+  return transform(parse(clean(validate(markdown))));
 }

--- a/src/utils/clean.ts
+++ b/src/utils/clean.ts
@@ -1,0 +1,11 @@
+import { BLANK, CODE_BLOCK_REGEX } from '../constants';
+
+/**
+ * Cleans Markdown.
+ *
+ * @param markdown - The raw Markdown.
+ * @returns - The cleaned Markdown.
+ */
+export function clean(markdown: string): string {
+  return markdown.replace(CODE_BLOCK_REGEX, BLANK).trim();
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './clean';
 export * from './parse';
 export * from './transform';
 export * from './validate';


### PR DESCRIPTION
## What is the motivation for this pull request?

Fixes #201

## What is the current behavior?

Code block with heading-like syntax are parsed in TOC

## What is the new behavior?

Code block with heading-like syntax are excluded from TOC generation

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation